### PR TITLE
Simplify tox commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: dev
 dev: python
-	tox -q -e py36-dev
+	@tox -q
 
 .PHONY: shell
 shell: python
-	tox -q -e py36-shell
+	@tox -qe shell
 
 .PHONY: clean
 clean:
-	rm -rf .tox
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
+	@rm -rf .tox
+	@find . -type f -name "*.py[co]" -delete
+	@find . -type d -name "__pycache__" -delete
 
 .PHONY: python
 python:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+.PHONY: help
+help: 
+        @echo "make help              Show this help message"
+        @echo "make dev               Run the app in the development server"
+        @echo "make shell             Launch a Python shell in the dev environment"
+        @echo "make clean             Delete development artefacts (cached files, "
+        @echo "                       dependencies, etc)"
+
 .PHONY: dev
 dev: python
 	@tox -q

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A pretend LMS for testing LTI apps.
 
 ## You will need
 
-* [Make](https://www.gnu.org/software/make/)
-
 * [Git](https://git-scm.com/)
 
 * [pyenv](https://github.com/pyenv/pyenv)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36-dev,py36-shell
+envlist = dev
 minversion = 3.8.0
 requires =
     tox-pip-extensions


### PR DESCRIPTION
Simplify tox commands.

Quieten `make clean`.

Remove GNU Make from README -- it gets installed while installing pyenv
anyway.